### PR TITLE
Update /ping api for single endpoint setup

### DIFF
--- a/src/Ping.tsx
+++ b/src/Ping.tsx
@@ -8,6 +8,17 @@ function Ping(): JSX.Element {
     received_at: '',
   })
 
+  const createBaseUrl = (): string => {
+    const locationToMatchRegex = new RegExp('^http://localhost:[0-9]*')
+    if (locationToMatchRegex.test(window.location.origin)) {
+      // The http://host:port that serves backend in a single endpoint setup.
+      return 'http://localhost:3000'
+    }
+    // The current window URL in a single endpoint setup.
+    // Backend is served via /ping path_prefix.
+    return window.location.origin
+  }
+
   const handleChange = (e: {
     target: { value: React.SetStateAction<string> }
   }) => {
@@ -18,7 +29,8 @@ function Ping(): JSX.Element {
     e.preventDefault()
 
     const pingServer = async (query: string) => {
-      const response = await fetch(`http://localhost:3000/ping?ping=${query}`)
+      const baseUrl = createBaseUrl()
+      const response = await fetch(`${baseUrl}/ping?ping=${query}`)
       const data = await response.json()
       setPong(data)
     }

--- a/src/Ping.tsx
+++ b/src/Ping.tsx
@@ -1,12 +1,14 @@
+/* eslint-disable camelcase */
+
 import React, { useState } from 'react'
 import './Ping.css'
 
 function Ping(): JSX.Element {
   const [ping, setPing] = useState('')
-  const [pong, setPong] = useState({
-    ping: '',
-    received_at: '',
-  })
+  const [pong, setPong] = useState<{
+    ping: string
+    received_at: string
+  } | null>(null)
 
   const createBaseUrl = (): string => {
     const locationToMatchRegex = new RegExp('^http://localhost:[0-9]*')

--- a/src/Ping.tsx
+++ b/src/Ping.tsx
@@ -11,7 +11,7 @@ function Ping(): JSX.Element {
   } | null>(null)
 
   const createBaseUrl = (): string => {
-    const locationToMatchRegex = new RegExp('^http://localhost:[0-9]*')
+    const locationToMatchRegex = new RegExp('^http:\/\/localhost(:[0-9]+)?')
     if (locationToMatchRegex.test(window.location.origin)) {
       // The http://host:port that serves backend in a single endpoint setup.
       return 'http://localhost:3000'


### PR DESCRIPTION
This PR updates the /ping api to handle single endpoint setup. Frontend/backend templates can now interact out of the box in any configuration.